### PR TITLE
Make progressbar transition linear && update apm staging registry

### DIFF
--- a/app/src/components/CustomProgressBar.js
+++ b/app/src/components/CustomProgressBar.js
@@ -33,6 +33,6 @@ const Wrapper = styled.div`
   padding: ${GU}px 0px;
 
   & > div > div {
-    transition: transform 1.5s ease;
+    transition: transform 1s linear;
   }
 `

--- a/arapp.json
+++ b/arapp.json
@@ -32,8 +32,8 @@
       "appName": "delay.open.aragonpm.eth"
     },
     "staging": {
-      "registry": "0x98df287b6c145399aaa709692c8d308357bc085d",
-      "appName": "delay-staging.open.aragonpm.eth",
+      "registry": "0xfe03625ea880a8cba336f9b5ad6e15b0a3b5a939",
+      "appName": "delay.open.aragonpm.eth",
       "wsRPC": "wss://rinkeby.eth.aragon.network/ws",
       "network": "rinkeby"
     },


### PR DESCRIPTION
APM Staging registry has been updated so we can use it now instead of using the traditional rinkeby apm repo with the staging tag on the package name

Also fixed the progress bar transition to a linear effect